### PR TITLE
Remove @api.multi that was move to core in Odoo 13

### DIFF
--- a/sale_order_price_recalculation/models/sale_order.py
+++ b/sale_order_price_recalculation/models/sale_order.py
@@ -12,7 +12,6 @@ from odoo import api, models
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    @api.multi
     def recalculate_prices(self):
         for line in self.mapped('order_line'):
             dict = line._convert_to_write(line.read()[0])
@@ -24,7 +23,6 @@ class SaleOrder(models.Model):
             line.price_unit = line2.price_unit
         return True
 
-    @api.multi
     def recalculate_names(self):
         for line in self.mapped('order_line').filtered('product_id'):
             # we make this to isolate changed values:


### PR DESCRIPTION
This module also blocks Odoo from starting. This is a fix found here https://www.odoo.com/de_DE/forum/hilfe-1/attributeerror-module-odooapi-has-no-attribute-multi-156849

The error I was getting

```
025-07-02 04:02:04,976 131 CRITICAL odoo odoo.service.server: Failed to initialize database `odoo`. 
Traceback (most recent call last):
  File "/opt/odoo/odoo/service/server.py", line 1199, in preload_registries
    registry = Registry.new(dbname, update_module=update_module)
  File "/opt/odoo/odoo/modules/registry.py", line 89, in new
    odoo.modules.load_modules(registry._db, force_demo, status, update_module)
  File "/opt/odoo/odoo/modules/loading.py", line 459, in load_modules
    processed_modules += load_marked_modules(cr, graph,
  File "/opt/odoo/odoo/modules/loading.py", line 347, in load_marked_modules
    loaded, processed = load_module_graph(
  File "/opt/odoo/odoo/modules/loading.py", line 179, in load_module_graph
    load_openerp_module(package.name)
  File "/opt/odoo/odoo/modules/module.py", line 385, in load_openerp_module
    __import__('odoo.addons.' + module_name)
  File "/mnt/extra-addons/sale_order_price_recalculation/__init__.py", line 3, in <module>
    from . import models
  File "/mnt/extra-addons/sale_order_price_recalculation/models/__init__.py", line 8, in <module>
    from . import sale_order
  File "/mnt/extra-addons/sale_order_price_recalculation/models/sale_order.py", line 12, in <module>
    class SaleOrder(models.Model):
  File "/mnt/extra-addons/sale_order_price_recalculation/models/sale_order.py", line 15, in SaleOrder
    @api.multi
AttributeError: module 'odoo.api' has no attribute 'multi'
```